### PR TITLE
Remove the restriction on usability for tests only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 
 setup(
     name='pytest-data',
-    version='0.4',
+    version='0.5',
     packages=['pytest_data'],
 
     url='https://github.com/horejsek/python-pytest-data',


### PR DESCRIPTION
In some cases it may be expensive to run fixtures for every test while running them once per module may be good enough.

In order to do that, we had to remove the restrictions that force function scope and `test_` function name prefix.